### PR TITLE
time.clock() function was deprecated since Python 3.3 and removed in …

### DIFF
--- a/src/converter.py
+++ b/src/converter.py
@@ -55,21 +55,21 @@ class Converter(object):
         parser.setContentHandler(importer)
         parser.setEntityResolver(DTDResolver())
 
-        t1 = time.clock()
+        t1 = time.time()
         try:
             parser.parse("file:" + self._inputfile)
         except urllib.error.URLError as urlError:
             raise FileNotFoundError(urlError)
-        t2 = time.clock()
+        t2 = time.time()
         print("Einlesen:")
         self.computeDuration(t1, t2)
         logging.info("Daten eingelesen")
 
         exporter = PyxelExporter(importer.articles, self._outputfile, self._manufacturerName)
         logging.info("Erstelle Excel-Datei")
-        t3 = time.clock()
+        t3 = time.time()
         exporter.createNewWorkbook()
-        t4 = time.clock()
+        t4 = time.time()
         print("Wegschreiben:")
         self.computeDuration(t3, t4)
         logging.info("Fertig.")
@@ -82,9 +82,9 @@ class Converter(object):
         importer = ExcelImporter(self._separatorTransformer)
 
         if os.path.isfile(self._inputfile):
-            t1 = time.clock()
+            t1 = time.time()
             importer.readWorkbook(self._inputfile)
-            t2 = time.clock()
+            t2 = time.time()
             print("Einlesen:")
             self.computeDuration(t1, t2)
 
@@ -97,9 +97,9 @@ class Converter(object):
 
             logging.info("Erstelle XML-Datei")
             print("Erstelle XML-Datei")
-            t3 = time.clock()
+            t3 = time.time()
             exporter.writeBMEcatAsXML()
-            t4 = time.clock()
+            t4 = time.time()
             print("Wegschreiben:")
             self.computeDuration(t3, t4)
         else:

--- a/src/main.py
+++ b/src/main.py
@@ -197,7 +197,7 @@ def computeDuration(beginning):
     """
     compute duration from beginning to end.
     """
-    duration = time.clock() - beginning
+    duration = time.time() - beginning
     if duration < 60:
         print('Duration in seconds: %d', duration)
     else:

--- a/src/main.py
+++ b/src/main.py
@@ -168,7 +168,7 @@ def main(argv):
     logging.debug('Number of arguments: %d arguments.', len(argv))
     logging.debug('Argument List: %s', str(argv))
 
-    startingTime = time.clock()
+    startingTime = time.time()
 
     try:
         argumentParser = ArgumentParser()


### PR DESCRIPTION
…Python 3.8. 
Use time.time() instead, tested with Python 3.10.